### PR TITLE
Add queries for filtering asylum decisions and refugee naturalization…

### DIFF
--- a/src/main/java/com/beyondfootsteps/beyondfootsteps/models/AsylumDecision.java
+++ b/src/main/java/com/beyondfootsteps/beyondfootsteps/models/AsylumDecision.java
@@ -41,5 +41,5 @@ public class AsylumDecision {
 
     private Float acceptanceRate;
 
-    private Integer intakeDate;
+    private Boolean decPc;
 }

--- a/src/main/java/com/beyondfootsteps/beyondfootsteps/repositories/AsylumDecisionRepository.java
+++ b/src/main/java/com/beyondfootsteps/beyondfootsteps/repositories/AsylumDecisionRepository.java
@@ -1,11 +1,22 @@
 package com.beyondfootsteps.beyondfootsteps.repositories;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.beyondfootsteps.beyondfootsteps.models.AsylumDecision;
 
 @Repository
-public interface AsylumDecisionRepository extends JpaRepository<AsylumDecision, String>{
+public interface AsylumDecisionRepository extends JpaRepository<AsylumDecision, String> {
+
+    @Query("SELECT a FROM AsylumDecision a WHERE a.year = :year "
+            + "AND (:countryOfOriginIso IS NULL OR a.countryOfOriginIso = :countryOfOriginIso) "
+            + "AND (:countryOfAsylumIso IS NULL OR a.countryOfAsylumIso = :countryOfAsylumIso)")
+    List<AsylumDecision> findByYearAndCountries(@Param("year") int year,
+            @Param("countryOfOriginIso") String countryOfOriginIso,
+            @Param("countryOfAsylumIso") String countryOfAsylumIso);
 
 }

--- a/src/main/java/com/beyondfootsteps/beyondfootsteps/repositories/RefugeeNaturalizationRepository.java
+++ b/src/main/java/com/beyondfootsteps/beyondfootsteps/repositories/RefugeeNaturalizationRepository.java
@@ -1,11 +1,21 @@
 package com.beyondfootsteps.beyondfootsteps.repositories;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.beyondfootsteps.beyondfootsteps.models.RefugeeNaturalization;
 
 @Repository
-public interface RefugeeNaturalizationRepository extends JpaRepository<RefugeeNaturalization, String>{
+public interface RefugeeNaturalizationRepository extends JpaRepository<RefugeeNaturalization, String> {
 
+    @Query("SELECT a FROM RefugeeNaturalization a WHERE a.year = :year "
+            + "AND (:countryOfOriginIso IS NULL OR a.countryOfOriginIso = :countryOfOriginIso) "
+            + "AND (:countryOfAsylumIso IS NULL OR a.countryOfAsylumIso = :countryOfAsylumIso)")
+    List<RefugeeNaturalization> findByYearAndCountries(@Param("year") int year,
+            @Param("countryOfOriginIso") String countryOfOriginIso,
+            @Param("countryOfAsylumIso") String countryOfAsylumIso);
 }

--- a/src/main/java/com/beyondfootsteps/beyondfootsteps/resolvers/AsylumDecisionResolver.java
+++ b/src/main/java/com/beyondfootsteps/beyondfootsteps/resolvers/AsylumDecisionResolver.java
@@ -2,6 +2,7 @@ package com.beyondfootsteps.beyondfootsteps.resolvers;
 
 import java.util.List;
 
+import org.springframework.graphql.data.method.annotation.Argument;
 import org.springframework.graphql.data.method.annotation.QueryMapping;
 import org.springframework.stereotype.Controller;
 
@@ -19,5 +20,12 @@ public class AsylumDecisionResolver {
     @QueryMapping(name = "asylumDecisions")
     public List<AsylumDecision> findAll() {
         return asylumDecisionService.findAll();
+    }
+
+    @QueryMapping(name = "asylumDecisionsByYearAndCountry")
+    public List<AsylumDecision> findByYearAndCountry(@Argument int year, @Argument String countryOfOriginIso,
+            @Argument String countryOfAsylumIso) throws Exception {
+        return asylumDecisionService.findByYearAndCountry(year, countryOfOriginIso, countryOfAsylumIso);
+
     }
 }

--- a/src/main/java/com/beyondfootsteps/beyondfootsteps/resolvers/RefugeeNaturalizationResolver.java
+++ b/src/main/java/com/beyondfootsteps/beyondfootsteps/resolvers/RefugeeNaturalizationResolver.java
@@ -2,6 +2,7 @@ package com.beyondfootsteps.beyondfootsteps.resolvers;
 
 import java.util.List;
 
+import org.springframework.graphql.data.method.annotation.Argument;
 import org.springframework.graphql.data.method.annotation.QueryMapping;
 import org.springframework.stereotype.Controller;
 
@@ -19,6 +20,13 @@ public class RefugeeNaturalizationResolver {
     @QueryMapping(name = "refugeeNaturalizations")
     public List<RefugeeNaturalization> findAll() {
         return refugeeNaturalizationService.findAll();
+    }
+
+    @QueryMapping(name = "refugeeNaturalizationsByYearAndCountry")
+    public List<RefugeeNaturalization> findByYearAndCountry(@Argument int year, @Argument String countryOfOriginIso,
+            @Argument String countryOfAsylumIso) throws Exception {
+        return refugeeNaturalizationService.findByYearAndCountry(year, countryOfOriginIso, countryOfAsylumIso);
+
     }
 
 }

--- a/src/main/java/com/beyondfootsteps/beyondfootsteps/services/AsylumDecisionService.java
+++ b/src/main/java/com/beyondfootsteps/beyondfootsteps/services/AsylumDecisionService.java
@@ -18,4 +18,8 @@ public class AsylumDecisionService {
     public List<AsylumDecision> findAll() {
         return asylumDecisionRepository.findAll();
     }
+
+    public List<AsylumDecision> findByYearAndCountry(int year, String countryOfOriginIso, String countryOfAsylumIso) {
+        return asylumDecisionRepository.findByYearAndCountries(year, countryOfOriginIso, countryOfAsylumIso);
+    }
 }

--- a/src/main/java/com/beyondfootsteps/beyondfootsteps/services/RefugeeNaturalizationService.java
+++ b/src/main/java/com/beyondfootsteps/beyondfootsteps/services/RefugeeNaturalizationService.java
@@ -18,4 +18,8 @@ public class RefugeeNaturalizationService {
     public List<RefugeeNaturalization> findAll() {
         return refugeeNaturalizationRepository.findAll();
     }
+
+    public List<RefugeeNaturalization> findByYearAndCountry(int year, String countryOfOriginIso, String countryOfAsylumIso) {
+        return refugeeNaturalizationRepository.findByYearAndCountries(year, countryOfOriginIso, countryOfAsylumIso);
+    }
 }

--- a/src/main/resources/graphql/schema.graphqls
+++ b/src/main/resources/graphql/schema.graphqls
@@ -11,7 +11,7 @@ type AsylumDecision {
   decClosed: Int
   decTotal: Int
   acceptanceRate: Float
-  intakeDate: Int
+  decPc: Boolean
 }
 
 type AsylumRequest {
@@ -109,4 +109,6 @@ type Query {
   # Queries with filters
   dashboardSummariesByYear(year: Int!): [DashboardSummary]
   asylumRequestsByYearAndCountry(year: Int!, countryOfOriginIso: String, countryOfAsylumIso: String): [AsylumRequest]
+  asylumDecisionsByYearAndCountry(year: Int!, countryOfOriginIso: String, countryOfAsylumIso: String): [AsylumDecision]
+  refugeeNaturalizationsByYearAndCountry(year: Int!, countryOfOriginIso: String, countryOfAsylumIso: String): [RefugeeNaturalization]
 }


### PR DESCRIPTION
This pull request introduces new filtered query capabilities for both asylum decisions and refugee naturalizations, allowing users to retrieve records by year and country. It also updates the data model and GraphQL schema to reflect these changes.

### Filtered Query Functionality

* Added repository methods `findByYearAndCountries` to both `AsylumDecisionRepository` and `RefugeeNaturalizationRepository` to support filtering by year, country of origin, and country of asylum. [[1]](diffhunk://#diff-9488cdb7c87b92f0366204ba06dac0636faa311650e8406a77030c6b0409a9d2R3-R21) [[2]](diffhunk://#diff-ab1cca15902acf0f44ffbbe7bd89b37b16ed814890e89096d9a87cc22c360bdaR3-R20)
* Implemented corresponding service methods and GraphQL resolver methods to expose these filters via the API, enabling queries such as `asylumDecisionsByYearAndCountry` and `refugeeNaturalizationsByYearAndCountry`. [[1]](diffhunk://#diff-5a9896912538374fa3e70bb8c129f6394811dcc8f6cd8ffa5f8e2c2b89fdc7f8R21-R24) [[2]](diffhunk://#diff-a3bfe1182f9fc104262fed06570a3d00521592d48d9b775435271eaef95dccbeR21-R24) [[3]](diffhunk://#diff-dc3f316942fb94f19e12723b5fa4080658752ae5d8ee8f2dc6c0bf74db48ef8bR24-R30) [[4]](diffhunk://#diff-54350898042d4748535d859668613210ec341a8de75416d1c5181ee1537c3180R25-R31)
* Updated the GraphQL schema to include the new filtered queries for both asylum decisions and refugee naturalizations.

### Data Model and Schema Updates

* Replaced the `intakeDate` field with a new Boolean field `decPc` in the `AsylumDecision` model and updated the GraphQL schema accordingly. [[1]](diffhunk://#diff-a9dc481e0cee0272d3e21ec2932ca13967d7bfe698bbd30219da7ac73fa6638cL44-R44) [[2]](diffhunk://#diff-5d613a07ecc006fa385fa8218be2e1f29dc88cfc0b70bd043277fbd0e1c3ab1aL14-R14)