### PR TITLE
Develop

### DIFF
--- a/src/main/java/com/beyondfootsteps/beyondfootsteps/dto/internal/ResettlementSummaryGroupedByAsylumAndYearInternal.java
+++ b/src/main/java/com/beyondfootsteps/beyondfootsteps/dto/internal/ResettlementSummaryGroupedByAsylumAndYearInternal.java
@@ -1,0 +1,19 @@
+package com.beyondfootsteps.beyondfootsteps.dto.internal;
+
+public record ResettlementSummaryGroupedByAsylumAndYearInternal(
+        String countriesIso,
+        String countriesNames,
+        Number totalCases,
+        Number totalDepartures,
+        Number totalPersons,
+        Number totalNeeds,
+        Number totalSubmissions,
+        Number year,
+        Number coverageRate,
+        Number resettlementGap,
+        Number requestVsNeedsRatio,
+        Number submissionsEfficiency,
+        Number realizationRate
+        ) {
+
+}

--- a/src/main/java/com/beyondfootsteps/beyondfootsteps/dto/internal/ResettlementSummaryOriginGroupedInternal.java
+++ b/src/main/java/com/beyondfootsteps/beyondfootsteps/dto/internal/ResettlementSummaryOriginGroupedInternal.java
@@ -1,0 +1,18 @@
+package com.beyondfootsteps.beyondfootsteps.dto.internal;
+
+public record ResettlementSummaryOriginGroupedInternal(
+        String countriesIso,
+        String countriesNames,
+        Number totalCases,
+        Number totalDepartures,
+        Number totalPersons,
+        Number totalNeeds,
+        Number totalSubmissions,
+        Number coverageRate,
+        Number resettlementGap,
+        Number requestVsNeedsRatio,
+        Number submissionsEfficiency,
+        Number realizationRate
+        ) {
+
+}

--- a/src/main/java/com/beyondfootsteps/beyondfootsteps/dto/response/ResettlementSummaryOriginGroupedResponse.java
+++ b/src/main/java/com/beyondfootsteps/beyondfootsteps/dto/response/ResettlementSummaryOriginGroupedResponse.java
@@ -1,0 +1,17 @@
+package com.beyondfootsteps.beyondfootsteps.dto.response;
+
+public record ResettlementSummaryOriginGroupedResponse(
+        String countriesIso,
+        String countriesNames,
+        Integer totalCases,
+        Integer totalDepartures,
+        Integer totalPersons,
+        Integer totalNeeds,
+        Integer totalSubmissions,
+        Double coverageRate,
+        Double resettlementGap,
+        Double requestVsNeedsRatio,
+        Float submissionsEfficiency,
+        Double realizationRate) {
+
+}

--- a/src/main/java/com/beyondfootsteps/beyondfootsteps/dto/response/ResettlementSummaryOriginGroupedYearResponse.java
+++ b/src/main/java/com/beyondfootsteps/beyondfootsteps/dto/response/ResettlementSummaryOriginGroupedYearResponse.java
@@ -1,0 +1,18 @@
+package com.beyondfootsteps.beyondfootsteps.dto.response;
+
+public record ResettlementSummaryOriginGroupedYearResponse(
+        String countriesIso,
+        String countriesNames,
+        Integer totalCases,
+        Integer totalDepartures,
+        Integer totalPersons,
+        Integer totalNeeds,
+        Integer totalSubmissions,
+        Double coverageRate,
+        Double resettlementGap,
+        Double requestVsNeedsRatio,
+        Float submissionsEfficiency,
+        Double realizationRate,
+        Integer year) {
+
+}

--- a/src/main/java/com/beyondfootsteps/beyondfootsteps/mappers/ResettlementSummaryOriginGroupedMapper.java
+++ b/src/main/java/com/beyondfootsteps/beyondfootsteps/mappers/ResettlementSummaryOriginGroupedMapper.java
@@ -1,0 +1,48 @@
+package com.beyondfootsteps.beyondfootsteps.mappers;
+
+import com.beyondfootsteps.beyondfootsteps.dto.internal.ResettlementSummaryGroupedByAsylumAndYearInternal;
+import com.beyondfootsteps.beyondfootsteps.dto.internal.ResettlementSummaryOriginGroupedInternal;
+import com.beyondfootsteps.beyondfootsteps.dto.response.ResettlementSummaryOriginGroupedResponse;
+import com.beyondfootsteps.beyondfootsteps.dto.response.ResettlementSummaryOriginGroupedYearResponse;
+
+public class ResettlementSummaryOriginGroupedMapper {
+
+    private ResettlementSummaryOriginGroupedMapper() {
+    }
+
+    public static ResettlementSummaryOriginGroupedResponse toResponse(ResettlementSummaryOriginGroupedInternal internal) {
+        return new ResettlementSummaryOriginGroupedResponse(
+                internal.countriesIso(),
+                internal.countriesNames(),
+                internal.totalCases() != null ? internal.totalCases().intValue() : null,
+                internal.totalDepartures() != null ? internal.totalDepartures().intValue() : null,
+                internal.totalPersons() != null ? internal.totalPersons().intValue() : null,
+                internal.totalNeeds() != null ? internal.totalNeeds().intValue() : null,
+                internal.totalSubmissions() != null ? internal.totalSubmissions().intValue() : null,
+                internal.coverageRate() != null ? internal.coverageRate().doubleValue() : null,
+                internal.resettlementGap() != null ? internal.resettlementGap().doubleValue() : null,
+                internal.requestVsNeedsRatio() != null ? internal.requestVsNeedsRatio().doubleValue() : null,
+                internal.submissionsEfficiency() != null ? internal.submissionsEfficiency().floatValue() : null,
+                internal.realizationRate() != null ? internal.realizationRate().doubleValue() : null
+        );
+    }
+
+    public static ResettlementSummaryOriginGroupedYearResponse toResponseWithYear(ResettlementSummaryGroupedByAsylumAndYearInternal internal) {
+        return new ResettlementSummaryOriginGroupedYearResponse(
+                internal.countriesIso(),
+                internal.countriesNames(),
+                internal.totalCases() != null ? internal.totalCases().intValue() : null,
+                internal.totalDepartures() != null ? internal.totalDepartures().intValue() : null,
+                internal.totalPersons() != null ? internal.totalPersons().intValue() : null,
+                internal.totalNeeds() != null ? internal.totalNeeds().intValue() : null,
+                internal.totalSubmissions() != null ? internal.totalSubmissions().intValue() : null,
+                internal.coverageRate() != null ? internal.coverageRate().doubleValue() : null,
+                internal.resettlementGap() != null ? internal.resettlementGap().doubleValue() : null,
+                internal.requestVsNeedsRatio() != null ? internal.requestVsNeedsRatio().doubleValue() : null,
+                internal.submissionsEfficiency() != null ? internal.submissionsEfficiency().floatValue() : null,
+                internal.realizationRate() != null ? internal.realizationRate().doubleValue() : null,
+                internal.year() != null ? internal.year().intValue() : null
+        );
+    }
+
+}

--- a/src/main/java/com/beyondfootsteps/beyondfootsteps/repositories/ResettlementSummaryRepository.java
+++ b/src/main/java/com/beyondfootsteps/beyondfootsteps/repositories/ResettlementSummaryRepository.java
@@ -1,11 +1,113 @@
 package com.beyondfootsteps.beyondfootsteps.repositories;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import com.beyondfootsteps.beyondfootsteps.dto.internal.ResettlementSummaryGroupedByAsylumAndYearInternal;
+import com.beyondfootsteps.beyondfootsteps.dto.internal.ResettlementSummaryOriginGroupedInternal;
 import com.beyondfootsteps.beyondfootsteps.models.ResettlementSummary;
 
 @Repository
-public interface ResettlementSummaryRepository extends JpaRepository<ResettlementSummary, String>{
+public interface ResettlementSummaryRepository extends JpaRepository<ResettlementSummary, String> {
+
+    @Query("SELECT new com.beyondfootsteps.beyondfootsteps.dto.internal.ResettlementSummaryOriginGroupedInternal("
+            + "rssm.countryOfOriginIso, "
+            + "rssm.countryOfOrigin,"
+            + "SUM(rssm.cases), "
+            + "SUM(rssm.departuresTotal), "
+            + "SUM(rssm.persons), "
+            + "SUM(rssm.totalNeeds), "
+            + "SUM(rssm.submissionsTotal), "
+            + "COALESCE(CASE WHEN SUM(rssm.totalNeeds) > 0 THEN ROUND(SUM(rssm.departuresTotal)  * 1.0 / SUM(rssm.totalNeeds), 3) ELSE NULL END, NULL), "
+            + "COALESCE(SUM(rssm.totalNeeds) - SUM(rssm.departuresTotal), NULL), "
+            + "COALESCE(CASE WHEN SUM(rssm.totalNeeds) > 0 THEN ROUND(SUM(rssm.persons) * 1.0 / SUM(rssm.totalNeeds), 3) END, NULL), "
+            + "COALESCE(CASE WHEN SUM(rssm.submissionsTotal) > 0 THEN ROUND(SUM(rssm.persons) * 1.0 / SUM(rssm.submissionsTotal), 3) END, NULL), "
+            + "COALESCE(CASE WHEN SUM(rssm.submissionsTotal) > 0 THEN ROUND(SUM(rssm.departuresTotal) * 1.0 / SUM(rssm.submissionsTotal), 3) END, NULL)) "
+            + "FROM ResettlementSummary rssm WHERE rssm.year = :year GROUP BY rssm.countryOfOriginIso, rssm.countryOfOrigin")
+    List<ResettlementSummaryOriginGroupedInternal> findByYearGroupedByOriginCountry(int year);
+
+    @Query("SELECT new com.beyondfootsteps.beyondfootsteps.dto.internal.ResettlementSummaryOriginGroupedInternal("
+            + "rssm.countryOfAsylumIso, "
+            + "rssm.countryOfAsylum,"
+            + "SUM(rssm.cases), "
+            + "SUM(rssm.departuresTotal), "
+            + "SUM(rssm.persons), "
+            + "SUM(rssm.totalNeeds), "
+            + "SUM(rssm.submissionsTotal), "
+            + "COALESCE(CASE WHEN SUM(rssm.totalNeeds) > 0 THEN ROUND(SUM(rssm.departuresTotal) * 1.0 / SUM(rssm.totalNeeds), 3) ELSE NULL END, NULL), "
+            + "COALESCE(SUM(rssm.totalNeeds) - SUM(rssm.departuresTotal), NULL), "
+            + "COALESCE(CASE WHEN SUM(rssm.totalNeeds) > 0 THEN ROUND(SUM(rssm.persons) * 1.0 / SUM(rssm.totalNeeds), 3) END, NULL), "
+            + "COALESCE(CASE WHEN SUM(rssm.submissionsTotal) > 0 THEN ROUND(SUM(rssm.persons) * 1.0 / SUM(rssm.submissionsTotal), 3) END, NULL), "
+            + "COALESCE(CASE WHEN SUM(rssm.submissionsTotal) > 0 THEN ROUND(SUM(rssm.departuresTotal) * 1.0 / SUM(rssm.submissionsTotal), 3) END, NULL)) "
+            + "FROM ResettlementSummary rssm WHERE rssm.year = :year GROUP BY rssm.countryOfAsylumIso, rssm.countryOfAsylum")
+    List<ResettlementSummaryOriginGroupedInternal> findByYearGroupedByAsylumCountry(int year);
+
+    @Query("SELECT new com.beyondfootsteps.beyondfootsteps.dto.internal.ResettlementSummaryOriginGroupedInternal("
+            + "rssm.countryOfResettlementIso, "
+            + "rssm.countryOfResettlement,"
+            + "SUM(rssm.cases), "
+            + "SUM(rssm.departuresTotal), "
+            + "SUM(rssm.persons), "
+            + "SUM(rssm.totalNeeds), "
+            + "SUM(rssm.submissionsTotal), "
+            + "COALESCE(CASE WHEN SUM(rssm.totalNeeds) > 0 THEN ROUND(SUM(rssm.departuresTotal) * 1.0 / SUM(rssm.totalNeeds), 3) ELSE NULL END, NULL), "
+            + "COALESCE(SUM(rssm.totalNeeds) - SUM(rssm.departuresTotal), NULL), "
+            + "COALESCE(CASE WHEN SUM(rssm.totalNeeds) > 0 THEN ROUND(SUM(rssm.persons) * 1.0 / SUM(rssm.totalNeeds), 3) END, NULL), "
+            + "COALESCE(CASE WHEN SUM(rssm.submissionsTotal) > 0 THEN ROUND(SUM(rssm.persons) * 1.0 / SUM(rssm.submissionsTotal), 3) END, NULL), "
+            + "COALESCE(CASE WHEN SUM(rssm.submissionsTotal) > 0 THEN ROUND(SUM(rssm.departuresTotal) * 1.0 / SUM(rssm.submissionsTotal), 3) END, NULL)) "
+            + "FROM ResettlementSummary rssm WHERE rssm.year = :year GROUP BY rssm.countryOfResettlementIso, rssm.countryOfResettlement")
+    List<ResettlementSummaryOriginGroupedInternal> findByYearGroupedByResettlementCountry(int year);
+
+    @Query("SELECT new com.beyondfootsteps.beyondfootsteps.dto.internal.ResettlementSummaryOriginGroupedInternal("
+            + "CONCAT(rssm.countryOfOriginIso, '-',  rssm.countryOfAsylumIso), "
+            + "CONCAT(rssm.countryOfOrigin, '-',  rssm.countryOfAsylum), "
+            + "SUM(rssm.cases), "
+            + "SUM(rssm.departuresTotal), "
+            + "SUM(rssm.persons), "
+            + "SUM(rssm.totalNeeds), "
+            + "SUM(rssm.submissionsTotal), "
+            + "COALESCE(CASE WHEN SUM(rssm.totalNeeds) > 0 THEN ROUND(SUM(rssm.departuresTotal) * 1.0 / SUM(rssm.totalNeeds), 3) ELSE NULL END, NULL), "
+            + "COALESCE(SUM(rssm.totalNeeds) - SUM(rssm.departuresTotal), NULL), "
+            + "COALESCE(CASE WHEN SUM(rssm.totalNeeds) > 0 THEN ROUND(SUM(rssm.persons) * 1.0 / SUM(rssm.totalNeeds), 3) END, NULL), "
+            + "COALESCE(CASE WHEN SUM(rssm.submissionsTotal) > 0 THEN ROUND(SUM(rssm.persons) * 1.0 / SUM(rssm.submissionsTotal), 3) END, NULL), "
+            + "COALESCE(CASE WHEN SUM(rssm.submissionsTotal) > 0 THEN ROUND(SUM(rssm.departuresTotal) * 1.0 / SUM(rssm.submissionsTotal), 3) END, NULL)) "
+            + "FROM ResettlementSummary rssm WHERE rssm.year = :year GROUP BY rssm.countryOfOriginIso, rssm.countryOfAsylumIso, countryOfOrigin, countryOfAsylum")
+    List<ResettlementSummaryOriginGroupedInternal> findByYearGroupedByOriginAsylumCountry(int year);
+
+    @Query("SELECT new com.beyondfootsteps.beyondfootsteps.dto.internal.ResettlementSummaryOriginGroupedInternal("
+            + "CONCAT(rssm.countryOfAsylumIso, '-',  rssm.countryOfResettlementIso), "
+            + "CONCAT(rssm.countryOfAsylum, '-',  rssm.countryOfResettlement), "
+            + "SUM(rssm.cases), "
+            + "SUM(rssm.departuresTotal), "
+            + "SUM(rssm.persons), "
+            + "SUM(rssm.totalNeeds), "
+            + "SUM(rssm.submissionsTotal), "
+            + "COALESCE(CASE WHEN SUM(rssm.totalNeeds) > 0 THEN ROUND(SUM(rssm.departuresTotal) * 1.0 / SUM(rssm.totalNeeds), 3) ELSE NULL END, NULL), "
+            + "COALESCE(SUM(rssm.totalNeeds) - SUM(rssm.departuresTotal), NULL), "
+            + "COALESCE(CASE WHEN SUM(rssm.totalNeeds) > 0 THEN ROUND(SUM(rssm.persons) * 1.0 / SUM(rssm.totalNeeds), 3) END, NULL), "
+            + "COALESCE(CASE WHEN SUM(rssm.submissionsTotal) > 0 THEN ROUND(SUM(rssm.persons) * 1.0 / SUM(rssm.submissionsTotal), 3) END, NULL), "
+            + "COALESCE(CASE WHEN SUM(rssm.submissionsTotal) > 0 THEN ROUND(SUM(rssm.departuresTotal) * 1.0 / SUM(rssm.submissionsTotal), 3) END, NULL)) "
+            + "FROM ResettlementSummary rssm WHERE rssm.year = :year GROUP BY rssm.countryOfAsylumIso, rssm.countryOfResettlementIso, countryOfAsylum, countryOfResettlement")
+    List<ResettlementSummaryOriginGroupedInternal> findByYearGroupedByAsylumResettlementCountry(int year);
+
+    @Query("SELECT new com.beyondfootsteps.beyondfootsteps.dto.internal.ResettlementSummaryGroupedByAsylumAndYearInternal("
+            + "rssm.countryOfAsylumIso,"
+            + "rssm.countryOfAsylum, "
+            + "SUM(rssm.cases), "
+            + "SUM(rssm.departuresTotal), "
+            + "SUM(rssm.persons), "
+            + "SUM(rssm.totalNeeds), "
+            + "SUM(rssm.submissionsTotal), "
+            + "rssm.year,"
+            + "COALESCE(CASE WHEN SUM(rssm.totalNeeds) > 0 THEN ROUND(SUM(rssm.departuresTotal) * 1.0 / SUM(rssm.totalNeeds), 3) ELSE NULL END, NULL), "
+            + "COALESCE(SUM(rssm.totalNeeds) - SUM(rssm.departuresTotal), NULL), "
+            + "COALESCE(CASE WHEN SUM(rssm.totalNeeds) > 0 THEN ROUND(SUM(rssm.persons) * 1.0 / SUM(rssm.totalNeeds), 3) END, NULL), "
+            + "COALESCE(CASE WHEN SUM(rssm.submissionsTotal) > 0 THEN ROUND(SUM(rssm.persons) * 1.0 / SUM(rssm.submissionsTotal), 3) END, NULL), "
+            + "COALESCE(CASE WHEN SUM(rssm.submissionsTotal) > 0 THEN ROUND(SUM(rssm.departuresTotal) * 1.0 / SUM(rssm.submissionsTotal), 3) END, NULL)) "
+            + "FROM ResettlementSummary rssm GROUP BY rssm.countryOfAsylumIso, rssm.countryOfAsylum, rssm.year")
+    List<ResettlementSummaryGroupedByAsylumAndYearInternal> findGroupedByYearAndAsylumCountry();
 
 }

--- a/src/main/java/com/beyondfootsteps/beyondfootsteps/resolvers/ResettlementSummaryResolver.java
+++ b/src/main/java/com/beyondfootsteps/beyondfootsteps/resolvers/ResettlementSummaryResolver.java
@@ -2,9 +2,12 @@ package com.beyondfootsteps.beyondfootsteps.resolvers;
 
 import java.util.List;
 
+import org.springframework.graphql.data.method.annotation.Argument;
 import org.springframework.graphql.data.method.annotation.QueryMapping;
 import org.springframework.stereotype.Controller;
 
+import com.beyondfootsteps.beyondfootsteps.dto.response.ResettlementSummaryOriginGroupedResponse;
+import com.beyondfootsteps.beyondfootsteps.dto.response.ResettlementSummaryOriginGroupedYearResponse;
 import com.beyondfootsteps.beyondfootsteps.models.ResettlementSummary;
 import com.beyondfootsteps.beyondfootsteps.services.ResettlementSummaryService;
 
@@ -19,6 +22,16 @@ public class ResettlementSummaryResolver {
     @QueryMapping(name = "resettlementSummaries")
     public List<ResettlementSummary> findAll() {
         return resettlementSummaryService.findAll();
+    }
+
+    @QueryMapping(name = "resettlementSummariesByYearGroupedBy")
+    public List<ResettlementSummaryOriginGroupedResponse> findByYearGroupedBy(@Argument int year, @Argument String grouping) {
+        return resettlementSummaryService.findByYearGroupedBy(year, grouping);
+    }
+
+    @QueryMapping(name = "resettlementSummariesGroupedByAsylumYear")
+    public List<ResettlementSummaryOriginGroupedYearResponse> findGroupedByYear() {
+        return resettlementSummaryService.findGroupedByYear();
     }
 
 }

--- a/src/main/java/com/beyondfootsteps/beyondfootsteps/services/ResettlementSummaryService.java
+++ b/src/main/java/com/beyondfootsteps/beyondfootsteps/services/ResettlementSummaryService.java
@@ -4,6 +4,10 @@ import java.util.List;
 
 import org.springframework.stereotype.Service;
 
+import com.beyondfootsteps.beyondfootsteps.dto.internal.ResettlementSummaryOriginGroupedInternal;
+import com.beyondfootsteps.beyondfootsteps.dto.response.ResettlementSummaryOriginGroupedResponse;
+import com.beyondfootsteps.beyondfootsteps.dto.response.ResettlementSummaryOriginGroupedYearResponse;
+import com.beyondfootsteps.beyondfootsteps.mappers.ResettlementSummaryOriginGroupedMapper;
 import com.beyondfootsteps.beyondfootsteps.models.ResettlementSummary;
 import com.beyondfootsteps.beyondfootsteps.repositories.ResettlementSummaryRepository;
 
@@ -17,5 +21,28 @@ public class ResettlementSummaryService {
 
     public List<ResettlementSummary> findAll() {
         return resettlementSummaryRepository.findAll();
+    }
+
+    public List<ResettlementSummaryOriginGroupedResponse> findByYearGroupedBy(int year, String grouping) {
+        List<ResettlementSummaryOriginGroupedInternal> res = List.of();
+        switch (grouping.toUpperCase()) {
+            case "ORIGIN" ->
+                res = resettlementSummaryRepository.findByYearGroupedByOriginCountry(year);
+            case "ASYLUM" ->
+                res = resettlementSummaryRepository.findByYearGroupedByAsylumCountry(year);
+            case "RESETTLEMENT" ->
+                res = resettlementSummaryRepository.findByYearGroupedByResettlementCountry(year);
+            case "ORIGIN-ASYLUM" ->
+                res = resettlementSummaryRepository.findByYearGroupedByOriginAsylumCountry(year);
+            case "ASYLUM-RESETTLEMENT" ->
+                res = resettlementSummaryRepository.findByYearGroupedByAsylumResettlementCountry(year);
+            default -> {
+            }
+        }
+        return res.stream().map(ResettlementSummaryOriginGroupedMapper::toResponse).toList();
+    }
+
+    public List<ResettlementSummaryOriginGroupedYearResponse> findGroupedByYear() {
+        return resettlementSummaryRepository.findGroupedByYearAndAsylumCountry().stream().map(ResettlementSummaryOriginGroupedMapper::toResponseWithYear).toList();
     }
 }

--- a/src/main/resources/graphql/schema.graphqls
+++ b/src/main/resources/graphql/schema.graphqls
@@ -85,13 +85,50 @@ type RefugeeNaturalization {
 type ResettlementSummary {
   id: ID!
   year: Int
-  countryIso: String
-  totalRequests: Int
-  totalDepartures: Int
-  totalSubmissions: Int
+  countryOfOriginIso: String
+  countryOfOrigin: String
+  countryOfAsylumIso: String
+  countryOfAsylum: String
+  countryOfResettlementIso: String
+  countryOfResettlement: String
+  cases: Int
+  persons: Int
+  departuresTotal: Int
   totalNeeds: Int
-  totalGaps: Float
+  submissionsTotal: Int
+  resettlementGap: Float
   coverageRate: Float
+  requestVsNeedsRatio: Float
+  submissionsEfficiency: Float
+  realizationRate: Float
+}
+
+type ResettlementSummaryGrouped {
+  countriesIso: String
+  countriesNames: String
+  totalCases: Int
+  totalDepartures: Int
+  totalPersons: Int
+  totalNeeds: Int
+  totalSubmissions: Int
+  coverageRate: Float
+  resettlementGap: Float
+  requestVsNeedsRatio: Float
+  submissionsEfficiency: Float
+  realizationRate: Float
+}
+
+type ResettlementSummaryGroupedWithYear {
+  countriesIso: String
+  countriesNames: String
+  totalCases: Int
+  totalDepartures: Int
+  totalPersons: Int
+  year: Int
+  totalNeeds: Int
+  totalSubmissions: Int
+  coverageRate: Float
+  resettlementGap: Float
   requestVsNeedsRatio: Float
   submissionsEfficiency: Float
   realizationRate: Float
@@ -105,10 +142,28 @@ type Query {
   idpReturnees: [IdpReturnees]
   refugeeNaturalizations: [RefugeeNaturalization]
   resettlementSummaries: [ResettlementSummary]
+  resettlementSummariesGroupedByAsylumYear: [ResettlementSummaryGroupedWithYear]
 
   # Queries with filters
   dashboardSummariesByYear(year: Int!): [DashboardSummary]
-  asylumRequestsByYearAndCountry(year: Int!, countryOfOriginIso: String, countryOfAsylumIso: String): [AsylumRequest]
-  asylumDecisionsByYearAndCountry(year: Int!, countryOfOriginIso: String, countryOfAsylumIso: String): [AsylumDecision]
-  refugeeNaturalizationsByYearAndCountry(year: Int!, countryOfOriginIso: String, countryOfAsylumIso: String): [RefugeeNaturalization]
+  asylumRequestsByYearAndCountry(
+    year: Int!
+    countryOfOriginIso: String
+    countryOfAsylumIso: String
+  ): [AsylumRequest]
+  asylumDecisionsByYearAndCountry(
+    year: Int!
+    countryOfOriginIso: String
+    countryOfAsylumIso: String
+  ): [AsylumDecision]
+  refugeeNaturalizationsByYearAndCountry(
+    year: Int!
+    countryOfOriginIso: String
+    countryOfAsylumIso: String
+  ): [RefugeeNaturalization]
+  resettlementSummariesByYearGroupedBy(
+    year: Int!
+    grouping: String!
+  ): [ResettlementSummaryGrouped]
+
 }


### PR DESCRIPTION
This pull request introduces new DTOs, mappers, repository queries, service methods, and GraphQL schema updates to support advanced grouping and aggregation of resettlement summary data. The changes enable querying resettlement statistics grouped by various country combinations and years, with calculated metrics for each group.

The most important changes are:

**Data Model & DTOs**

* Added new internal DTOs (`ResettlementSummaryOriginGroupedInternal`, `ResettlementSummaryGroupedByAsylumAndYearInternal`) and response DTOs (`ResettlementSummaryOriginGroupedResponse`, `ResettlementSummaryOriginGroupedYearResponse`) to represent grouped and aggregated resettlement summary data with calculated metrics. [[1]](diffhunk://#diff-f2b3f184fc0cccf9273324de70f9b49a747e6b9fe4524d08e897afa7ace8b775R1-R18) [[2]](diffhunk://#diff-fd8254f82e0d6395dd630ecacf5c8885794aba78a1ef8e3edd0d7a94396a74a5R1-R19) [[3]](diffhunk://#diff-61e920321ee90f96d9830a30dfca674ae08e964fc75661baf49da46c5dfd8cf2R1-R17) [[4]](diffhunk://#diff-dbf2be0832ae829865a4373944a7edf83a27552a31fceb1835326280dbe84e6cR1-R18)

**Mapping Layer**

* Introduced `ResettlementSummaryOriginGroupedMapper` to convert internal DTOs to response DTOs for GraphQL responses, handling type conversions and null safety.

**Repository Layer**

* Added multiple custom JPQL queries in `ResettlementSummaryRepository` to fetch grouped resettlement summary data by origin, asylum, resettlement countries, and combinations, as well as by year. These queries calculate aggregated values and derived metrics (e.g., coverage rate, gap, efficiency).

**Service Layer**

* Implemented service methods to call the new repository queries and use the mapper for returning the correct DTOs to the resolver, supporting flexible grouping based on parameters.

**GraphQL API**

* Updated the GraphQL schema and resolver to expose new queries (`resettlementSummariesByYearGroupedBy`, `resettlementSummariesGroupedByAsylumYear`) and new types (`ResettlementSummaryGrouped`, `ResettlementSummaryGroupedWithYear`) for accessing grouped and aggregated resettlement summary data. [[1]](diffhunk://#diff-5d613a07ecc006fa385fa8218be2e1f29dc88cfc0b70bd043277fbd0e1c3ab1aL88-R131) [[2]](diffhunk://#diff-5d613a07ecc006fa385fa8218be2e1f29dc88cfc0b70bd043277fbd0e1c3ab1aR145-R168) [[3]](diffhunk://#diff-f2f58ee6990c0893992655f92530800c4fe695a7c1eee6e0bd72772f007fc39dR27-R36) [[4]](diffhunk://#diff-f2f58ee6990c0893992655f92530800c4fe695a7c1eee6e0bd72772f007fc39dR5-R10)